### PR TITLE
Remove explicit call to into_off

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,7 @@ fn app() {
     ufmt::uwriteln!(&mut serial, "Playing first song").unwrap();
     rumba.play_song(rumba::SongSlot::First).unwrap();
     delay_ms(2500);
-    ufmt::uwriteln!(&mut serial, "Stoping Roomba").unwrap();
-
-    rumba.into_off();
+    ufmt::uwriteln!(&mut serial, "Done!").unwrap();
 }
 
 #[arduino_uno::entry]


### PR DESCRIPTION
This is now done implicitly when dropping the rumba instance.